### PR TITLE
Health checks variables and update golang and docker-distribution

### DIFF
--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -79,6 +79,13 @@ properties:
       readonly:
         enabled: false
 
+  docker.registry.health_storagedriver_enabled:
+    description: Enable periodic health check on the storage driver's backend storage
+    default: true
+  docker.registry.health_cache_enabled:
+    description: In case of cache is defined, enables a periodic health check on the redis host and port
+    default: true
+
   docker.mirror.host:
     description: Enables a registry to be configured as a pull through cache to the official Docker Hub. See mirror for more information
     example: https://registry-1.docker.io

--- a/jobs/registry/templates/config/registry.conf
+++ b/jobs/registry/templates/config/registry.conf
@@ -57,14 +57,16 @@ proxy:
 
 health:
   storagedriver:
-    enabled: true
+    enabled: <%= p('docker.registry.health_storagedriver_enabled', 'true') %>
     interval: 10s
     threshold: 3
-  <% if_p('docker.cache.host') do %>tcp:
-    - addr: <%= p('docker.cache.host') %>:<%= p('docker.cache.port','6379') %>
+  <% if p('docker.registry.health_cache_enabled') == true || p('docker.registry.health_cache_enabled') =~ (/(true|t|yes|y|1)$/i) %>
+  <% if_p('docker.cache.host') do |cachehost| %>tcp:
+    - addr: <%= cachehost %>:<%= p('docker.cache.port','6379') %>
       timeout: 3s
       interval: 30s
       threshold: 3
+  <% end %>
   <% end %>
 
 <% if_p('docker.cache.host') do %>

--- a/packages/distribution/packaging
+++ b/packages/distribution/packaging
@@ -15,7 +15,7 @@ export HOME=/var/vcap
 #       github page: https://github.com/docker/distribution/releases
 #
 
-VERSION=2.5.0
+VERSION=2.5.1
 REPO_NAME=github.com/docker/distribution
 REPO_DIR=${BOSH_INSTALL_TARGET}/src/${REPO_NAME}
 

--- a/packages/distribution/spec
+++ b/packages/distribution/spec
@@ -3,4 +3,4 @@ name: distribution
 dependencies:
 - golang
 files:
-- docker/distribution-2.5.0.tar.gz
+- docker/distribution-2.5.1.tar.gz

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -15,7 +15,7 @@ export HOME=/var/vcap
 #       download page: https://golang.org/dl
 #
 echo "Extracting go ... "
-tar xzf golang/go1.7.linux-amd64.tar.gz
+tar xzf golang/go1.7.3.linux-amd64.tar.gz
 
 echo "Installing go ..."
 cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 
 files:
-  - golang/go1.7.linux-amd64.tar.gz    # https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz
+  - golang/go1.7.3.linux-amd64.tar.gz    # https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz


### PR DESCRIPTION
* Make redis health check fail not fatal. When redis is enabled for caching, the template automatically creates a health check for redis, but that behavior is not always desirable. I have checked when redis cache is down, registry can still work (with worse performance) but if the health check is enabled, registry will refuse to work and will show an error. This patch adds two new variables: "registry.health_storagedriver_enabled" and "registry.health_cache_enabled" with "true" as default values to maintain the compatibility.
* Update registry to 2.5.1 (because of the improvements in the catalog to list the containers)
* Update golang to 1.7.3