### PR TITLE
Enable /debug/health endpoint and monit restart

### DIFF
--- a/jobs/registry/monit
+++ b/jobs/registry/monit
@@ -2,4 +2,15 @@ check process registry
   with pidfile /var/vcap/sys/run/registry/registry.pid
   start program "/var/vcap/jobs/registry/bin/monit_debugger registry '/var/vcap/jobs/registry/bin/ctl start'"
   stop program "/var/vcap/jobs/registry/bin/monit_debugger registry '/var/vcap/jobs/registry/bin/ctl stop'"
+  if 7 restarts within 10 cycles then unmonitor
+<% if p('docker.registry.debug_endpoint_monit') == true || p('docker.registry.debug_endpoint_monit') =~ (/(true|t|yes|y|1)$/i)
+  debug = p('docker.registry.debug_endpoint')
+  port = debug.split(':')[1].to_s
+  host = (debug.split(':')[0].to_s.empty?) ? '127.0.0.1' : debug.split(':')[0].to_s
+  %>
+  if failed host <%= host %> port <%= port %>
+    send "GET /debug/health HTTP/1.1\r\nUser-Agent: monit-health-check\r\nHost: <%= host %>:<%= port %>\r\nConnection: close\r\n\r\n\"
+    expect "HTTP/[0-9\.]{3} 200 OK\r\n"
+    for 1 cycles then restart
+<% end %>
   group vcap

--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -28,9 +28,15 @@ properties:
   docker.registry.endpoint:
     description: Externally-reachable address for the registry, as a fully qualified URL. If present, it is used when creating generated URLs. Otherwise, these URLs are derived from client requests
     example: "https://myregistryaddress.org:5000"
-  docker.registry.debug:
+  docker.registry.debug_endpoint:
     description: Debug endpoint can be used for monitoring registry metrics and health, as well as profiling
-    example: "localhost:5001"
+    default: "127.0.0.1:5001"
+  docker.registry.debug_endpoint_enabled:
+    description: Debug endpoint enabled or disabled. It will create a log file with the dump of the health endpoint everytime the app it is stopped, useful with monit.
+    default: true
+  docker.registry.debug_endpoint_monit:
+    description: Enable monit restart capability using the debug endpoint. Setting to true will enable the debug endpoint.
+    default: true
   docker.registry.ofiles:
     description: Open files (ulimit)
     default: 10000

--- a/jobs/registry/templates/bin/ctl
+++ b/jobs/registry/templates/bin/ctl
@@ -23,6 +23,22 @@ case $1 in
     echo $! > $PIDFILE
     ;;
   stop)
+<% if p('docker.registry.debug_endpoint_enabled') == true ||
+      p('docker.registry.debug_endpoint_enabled') =~ (/(true|t|yes|y|1)$/i)
+  debug = p('docker.registry.debug_endpoint')
+  port = debug.split(':')[1].to_s
+  host = (debug.split(':')[0].to_s.empty?) ? '127.0.0.1' : debug.split(':')[0].to_s
+  %>
+    (
+        echo "$(date +%y:%m:%d-%H:%M:%S) GET http://<%= host %>/<%= port %>/debug/health" >> $LOG_DIR/$JOB_NAME.health.log
+        exec 9<> /dev/tcp/<%= host %>/<%= port %>
+        echo -e "GET /debug/health HTTP/1.0\r\n\r\n" >&9
+        cat <&9 | tee -a $LOG_DIR/$JOB_NAME.health.log
+        echo >> $LOG_DIR/$JOB_NAME.health.log
+        echo "$(date +%y:%m:%d-%H:%M:%S) DONE" >> $LOG_DIR/$JOB_NAME.health.log
+        exec 9>&-
+    )
+<% end %>
     kill_and_wait $PIDFILE
     ;;
   *)

--- a/jobs/registry/templates/config/registry.conf
+++ b/jobs/registry/templates/config/registry.conf
@@ -14,8 +14,11 @@ http:
   <% end %>
   <% if_p('docker.registry.endpoint') do |endpoint| %>host: <%= endpoint %>
   <% end %>
-  <% if_p('docker.registry.debug') do |debug| %>debug:
-    addr: <%= debug %>
+  <% if p('docker.registry.debug_endpoint_monit') == true ||
+        p('docker.registry.debug_endpoint_monit') =~ (/(true|t|yes|y|1)$/i) ||
+        p('docker.registry.debug_endpoint_enabled') == true ||
+        p('docker.registry.debug_endpoint_enabled') =~ (/(true|t|yes|y|1)$/i) %>debug:
+    addr: <%= p('docker.registry.debug_endpoint') %>
   <% end %>
   headers:
     X-Content-Type-Options: [nosniff]


### PR DESCRIPTION
Sometimes registry shows HTTP 503 errors because of the health checks (by default are cache -redis- and storage). It is difficult to track what the reason of the 503 and nobody is restarting the process.

This patch defines the `/debug/health` endpoint listening to `127.0.0.1:5001` (default) and the ctl script will dump the contents of  `http://127.0.0.1:5001/debug/health` in a new logfile `registry.health.log` everytime the process is stopped via the `ctl` script. Also it enables (by default) a monit check to `/v2/` endpoint to restart the process if the answer is not 200 HTTP code.

The new settings are enable by default because the health endpoint is only listening on 127.0.0.1

This was implemented because there are no plans to replace monit anymore in Bosh, but the `unmonitor` definition (in order to give it up if there are a lot of restarts) does not work with monit 5.2.5. It will work with the new stemcells.