### PR TITLE
Default registry API to bind to 127.0.0.1

### DIFF
--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -19,6 +19,7 @@ templates:
 properties:
   docker.registry.bind:
     description: What address to bind the Docker Registry v2 API
+    default: 127.0.0.1
   docker.registry.port:
     description: What port to run the Docker Registry v2 API on
     default: 5000


### PR DESCRIPTION
When not explicitly specified, registry API is exposed on port `5000` on the VM's external IP. This makes the default deployment less secure as it allows unencrypted access that bypasses nginx's SSL termination as well as any basic auth that might have been configured.

Binding it to `127.0.0.1` refuses connections using the external IPs. Also, since proxy uses this as the default backend IP, it continues to work as expected.