### PR TITLE
Add support for HTTP proxy

### DIFF
--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -134,3 +134,15 @@ properties:
             timeout: 500ms
             threshold: 5
             backoff: 1s
+
+  docker.registry.http_proxy:
+    description: HTTP proxy to access other resources, like the upstream docker registry.
+    example: http://proxy.company.com:8888
+
+  docker.registry.https_proxy:
+    description: HTTPS proxy to access other resources, like the upstream docker registry.
+    example: https://proxy.company.com:8443
+
+  docker.registry.no_proxy:
+    description: Comma separated list of ips, hosts to exclude from the HTTP proxy connections
+    example: localhost,.local,.internal.mycompany.com,192.168.0.1,192.168.0.2

--- a/jobs/registry/templates/bin/ctl
+++ b/jobs/registry/templates/bin/ctl
@@ -11,6 +11,15 @@ export LANG=en_US.UTF-8
 case $1 in
   start)
     pid_guard $PIDFILE $JOB_NAME
+    <%- if_p('docker.registry.http_proxy') do |v| %>
+      export http_proxy="<%= v %>"
+    <%- end %>
+    <%- if_p('docker.registry.https_proxy') do |v| %>
+      export https_proxy="<%= v %>"
+    <%- end %>
+    <%- if_p('docker.registry.no_proxy') do |v| %>
+      export no_proxy="<%= v %>"
+    <%- end %>
     (
         {
             # Set limitations on system resources


### PR DESCRIPTION
Many corporate networks do not allow access directly to the Internet and
require the use of an HTTP proxy. This commit adds support for
http_proxy, https_proxy and no_proxy environment variables being passed
to the registry daemon.