### PR TITLE
Add option to only require auth for privileged actions

### DIFF
--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -55,3 +55,6 @@ properties:
     example:
       user: "{PLAIN}password"
       user2: "$(openssl passwd -crypt PASSWORD)"
+  docker.proxy.only_auth_for_admin:
+    description: If true, only administrative actions require authentication
+    default: false

--- a/jobs/proxy/templates/config/nginx.conf
+++ b/jobs/proxy/templates/config/nginx.conf
@@ -71,9 +71,15 @@ http {
       }
 
       <% if_p("docker.proxy.auth_basic") do %>
+      <% if p("docker.proxy.only_auth_for_admin", false) %>
+      limit_except GET {
+      <% end %>
       # To add basic authentication to v2 use auth_basic setting.
       auth_basic "Registry Realm";
       auth_basic_user_file auth/registry;
+      <% if p("docker.proxy.only_auth_for_admin", false) %>
+      }
+      <% end %>
       <% end %>
 
       ## If $docker_distribution_api_version is empty, the header will not be added.


### PR DESCRIPTION
This restricts uploading new images, changing existing ones, etc. to
client that authenticate succesfully, while unauthenticated clients can
pull information about images as well as image data.