### PR TITLE
Allow custom TLS versions + dhparam settings in the proxy job

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+# Improvements
+
+- The `proxy` job can now be configured to specify exact TLS versions
+  to enable via the `docker.proxy.ssl.protocols` property. This defaults
+  to `TLSv1.1 TLSv1.2`. To enable TLS 1.2 only, change the value to `TLSv1.2`.
+- The `proxy` job can now be configured with a custom DH param PEM via the
+  `docker.proxy.ssl.dhparam` property. If the property is omitted, nginx's
+  default dhparam settings will be used. 

--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -16,6 +16,7 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   tls/cert.pem: tls/cert.pem
   tls/key.pem: tls/key.pem
+  tls/dhparam.pem: tls/dhparam.pem
 
 properties:
   docker.proxy.loglevel:
@@ -58,3 +59,8 @@ properties:
   docker.proxy.only_auth_for_admin:
     description: If true, only administrative actions require authentication
     default: false
+  docker.proxy.ssl.protocols:
+    description: "TLS Protocols to enable in the Docker proxy (space separated)"
+    default: "TLSv1.1 TLSv1.2"
+  docker.proxy.ssl.dhparam:
+    description: "Custom DH param for nginx to use"

--- a/jobs/proxy/templates/config/nginx.conf
+++ b/jobs/proxy/templates/config/nginx.conf
@@ -28,10 +28,14 @@ http {
   error_log  /var/vcap/sys/log/proxy/proxy-error.log <%= p('docker.proxy.loglevel', 'error') %>;
 
   # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-  ssl_protocols TLSv1.1 TLSv1.2;
+  ssl_protocols <%= p('docker.proxy.ssl.protocols') %>;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
+<% if_p('docker.proxy.ssl.dhparam') do |dhparam| %>
+  ssl_dhparam /var/vcap/jobs/proxy/tls/dhparam.pem;
+<% end %>
+
 
   ## Set a variable to help us decide if we need to add the
   ## 'Docker-Distribution-Api-Version' header.

--- a/jobs/proxy/templates/tls/dhparam.pem
+++ b/jobs/proxy/templates/tls/dhparam.pem
@@ -1,0 +1,1 @@
+<% if_p('docker.proxy.ssl.dhparam') do |x| %><%= x %><% end %>


### PR DESCRIPTION
- The `proxy` job can now be configured to specify exact TLS versions
  to enable via the `docker.proxy.ssl.protocols` property. This defaults
  to `TLSv1.1 TLSv1.2`. To enable TLS 1.2 only, change the value to `TLSv1.2`.
- The `proxy` job can now be configured with a custom DH param PEM via the
  `docker.proxy.ssl.dhparam` property. If the property is omitted, nginx's
  default dhparam settings will be used.

Signed-off-by: Abdel Fane <abdel.fane@allstate.com>