### PR TITLE
Updates docker distribution binary from 2.5.1 to 2.6.2

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+##  Updated packages
+
+
+Updates docker distribution binary from 2.5.1 to 2.6.2.

--- a/packages/distribution/packaging
+++ b/packages/distribution/packaging
@@ -15,7 +15,7 @@ export HOME=/var/vcap
 #       github page: https://github.com/docker/distribution/releases
 #
 
-VERSION=2.5.1
+VERSION=2.6.2
 REPO_NAME=github.com/docker/distribution
 REPO_DIR=${BOSH_INSTALL_TARGET}/src/${REPO_NAME}
 

--- a/packages/distribution/spec
+++ b/packages/distribution/spec
@@ -3,4 +3,4 @@ name: distribution
 dependencies:
 - golang
 files:
-- docker/distribution-2.5.1.tar.gz
+- docker/distribution-2.6.2.tar.gz


### PR DESCRIPTION
Docker distribution 2.6.x release notes:
https://github.com/docker/distribution/releases/tag/v2.6.2
https://github.com/docker/distribution/releases/tag/v2.6.1
https://github.com/docker/distribution/releases/tag/v2.6.0

This release update was sourced from https://github.com/docker/distribution/archive/v2.6.2.tar.gz