### PR TITLE
Docker cache without redis

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,7 @@
+##  Updated packages
+
+Updates docker distribution binary from 2.5.1 to 2.6.2.
+
 ##  New options
 
 `docker.cache.disabled: true` disables the blobdescriptor cache.  This can be useful in CI/CD environments using this boshrelease as a pullthrough cache due to a race condition that can occur if an image is pulled before it finishes uploading to the upstream registry.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,3 @@
 ##  New options
 
-docker.cache.disabled: true -disables the blobdescriptor cache.  This can be useful in CI/CD environments using this boshrelease as a pullthrough cache due to a race condition that can occur if an image is pulled before it finishes uploading to the upstream registry.
+`docker.cache.disabled: true` disables the blobdescriptor cache.  This can be useful in CI/CD environments using this boshrelease as a pullthrough cache due to a race condition that can occur if an image is pulled before it finishes uploading to the upstream registry.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,4 +1,3 @@
-##  Updated packages
+##  New options
 
-
-Updates docker distribution binary from 2.5.1 to 2.6.2.
+docker.cache.disabled: true -disables the blobdescriptor cache.  This can be useful in CI/CD environments using this boshrelease as a pullthrough cache due to a race condition that can occur if an image is pulled before it finishes uploading to the upstream registry.

--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -104,6 +104,9 @@ properties:
 
   docker.cache.host:
     description: IP address of the redis cache host
+  docker.cache.disabled:
+    description: Set to true to disable blobdescriptor cache.  This can be useful in pullthrough cache deployments where a container may be cached as not existing if it hasnt finished uploading to the upstream registry.
+    default: false
   docker.cache.port:
     description: Port address of the cache host
     default: 6379

--- a/jobs/registry/templates/config/registry.conf
+++ b/jobs/registry/templates/config/registry.conf
@@ -29,8 +29,11 @@ http:
   relativeurls: <%= p('docker.registry.relativeurls') == true ? 'yes' : 'no' %>
 
 storage:
-  cache:
+  <% !if_p('docker.cache.disabled', 'true') do %>
+  cache:  
     blobdescriptor: <% if_p('docker.cache.host') do %>redis<% end.else do %>inmemory<% end %>
+  <% end %>
+
   <% if_p('docker.registry.storage') do |storage| %>
   <% storage.each do |s, options| %><%= s %>:
     <% options.each do |key, value| %><% if s == 'gcs' && key == 'keyfile' %>keyfile: /var/vcap/jobs/registry/config/gcs.key<% else %><%= key %>: <%= value %><% end %>


### PR DESCRIPTION
`docker.cache.disabled: true` disables the blobdescriptor cache.  This can be useful in CI/CD environments using this boshrelease as a pullthrough cache due to a race condition that can occur if an image is pulled before it finishes uploading to the upstream registry.