### PR TITLE
Update docker distribution from 2.6.2 to 2.7.0 and golang from 1.7.3 to 1.11

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+## Updated packages
+
+Updates docker distribution binary from 2.6.2 to 2.7.0.
+Updated golang from 1.7.3 to 1.11
+

--- a/packages/distribution/packaging
+++ b/packages/distribution/packaging
@@ -15,7 +15,7 @@ export HOME=/var/vcap
 #       github page: https://github.com/docker/distribution/releases
 #
 
-VERSION=2.6.2
+VERSION=2.7.0
 REPO_NAME=github.com/docker/distribution
 REPO_DIR=${BOSH_INSTALL_TARGET}/src/${REPO_NAME}
 

--- a/packages/distribution/spec
+++ b/packages/distribution/spec
@@ -3,4 +3,4 @@ name: distribution
 dependencies:
 - golang
 files:
-- docker/distribution-2.6.2.tar.gz
+- docker/distribution-2.7.0.tar.gz

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -15,7 +15,7 @@ export HOME=/var/vcap
 #       download page: https://golang.org/dl
 #
 echo "Extracting go ... "
-tar xzf golang/go1.7.3.linux-amd64.tar.gz
+tar xzf golang/go1.11.linux-amd64.tar.gz
 
 echo "Installing go ..."
 cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 
 files:
-  - golang/go1.7.3.linux-amd64.tar.gz    # https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz
+  - golang/go1.11.linux-amd64.tar.gz    # https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz


### PR DESCRIPTION
Release Notes: https://github.com/docker/distribution/tree/v2.7.0
Tarball: https://github.com/docker/distribution/archive/v2.7.0.tar.gz