### PR TITLE
fix nfs_mounter and debian_nfs_server pre-start scripts

### DIFF
--- a/jobs/debian_nfs_server/templates/bin/pre-start
+++ b/jobs/debian_nfs_server/templates/bin/pre-start
@@ -44,7 +44,7 @@ esac
 echo "[$(date)] configuring NFS..."
 VCAP_UID=$(getent passwd vcap | cut -d : -f 3)
 VCAP_GID=$(getent passwd vcap | cut -d : -f 4)
-sed -e "s/\$VCAP_UID/$VCAP_UID/;s/\$VCAP_GID/$VCAP_GID/" \
+sed -e "s/\$VCAP_UID/$VCAP_UID/g;s/\$VCAP_GID/$VCAP_GID/g" \
        /var/vcap/jobs/debian_nfs_server/config/exports \
        > /etc/exports
 

--- a/jobs/nfs_mounter/templates/bin/pre-start
+++ b/jobs/nfs_mounter/templates/bin/pre-start
@@ -42,6 +42,8 @@ esac
 NFS_LOCAL=<%= p('nfs_server.share_path') %>
 NFS_REMOTE=<%= p('nfs_server.share', '/var/vcap/store') %>
 
+mkdir -p "$NFS_LOCAL"
+
 echo "[$(date)] mounting NFS at '$NFS_REMOTE' to '$NFS_LOCAL'"
 umount $NFS_LOCAL 2>/dev/null || true
 <% if properties.nfs_server.nfsv4 %>


### PR DESCRIPTION
Fix debian_nfs_server pre-start script to replace all instances of variables when creating /etc/exports
Update nfs_mounter pre-start script to create required mount point /var/vcap/nfs