### PR TITLE
variables to create server certs; require static IP; includes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,14 @@ bosh -d docker-registry deploy manifests/docker-registry.yml \
     -v ip=10.244.0.34
 ```
 
-
-Now add ca.pem to system CA (please let use know if there's a way for `docker login` to consume a local self-signed CA). For example, in Keychain it may look like:
+Now add `registry-ca.pem` to system CA (please let use know if there's a way for `docker login` to consume a local self-signed CA). For example, in Keychain it may look like:
 
 ![keychain](https://p198.p4.n0.cdn.getcloudapp.com/items/p9u5lR81/docker-registry-ca-keychain.png?v=0a5b64b4ab0ebf3538ad61d35d45557f)
 
 We can now `docker login` to our registry, tag `ubuntu:latest` as `10.244.0.34/ubuntu` and push it to our registry:
 
 ```bash
-docker login -u admin -p "$(cat password)" 10.244.0.34
+docker login -u admin -p "$(cat registry-password)" 10.244.0.34
 docker tag ubuntu 10.244.0.34/ubuntu
 docker push 10.244.0.34/ubuntu
 ```
@@ -70,6 +69,6 @@ docker push 10.244.0.34/ubuntu
 Our registry API confirms it now has the `ubuntu` image:
 
 ```plain
-$ curl https://10.244.0.34/v2/_catalog -u "admin:$(cat password)"
+$ curl https://10.244.0.34/v2/_catalog -u "admin:$(cat registry-password)"
 {"repositories":["ubuntu"]}
 ```

--- a/README.md
+++ b/README.md
@@ -1,241 +1,46 @@
-Private Docker Registry deployed with BOSH
-==========================================
+# Private Docker Registry deployed with BOSH
 
-Run your own private Docker Registry in standalone mode (without requiring the public index) on AWS, OpenStack or vSphere.
+Run your own private Docker Registry in standalone mode (without requiring the public index).
 
-For example, tagging and pushing the public `ubuntu:13.04` repository to an AWS-deployed Docker repository:
+For example, tagging and pushing the public `ubuntu:latest` repository to your Docker repository:
 
-```
-$ docker tag ubuntu:13.04 ec2-54-80-246-141.compute-1.amazonaws.com:5000/ubuntu-1304
-$ docker push ec2-54-80-246-141.compute-1.amazonaws.com:5000/ubuntu-1304
-The push refers to a repository [ec2-54-80-246-141.compute-1.amazonaws.com:5000/ubuntu-1304] (len: 1)
-Sending image list
-Pushing repository ec2-54-80-246-141.compute-1.amazonaws.com:5000/ubuntu-1304 (1 tags)
-511136ea3c5a: Image successfully pushed
-f323cf34fd77: Image successfully pushed
-eb601b8965b8: Pushing [==================>                                ] 68.77 MB/181.2 MB 4m1s
+```plain
+bosh -d docker-registry deploy \
+    manifests/docker-registry.yml \
+    -v ip=10.244.0.34
 ```
 
-Usage
------
+Now fetch the self-signed root CA, and the admin basic-auth password, and store in local files:
 
-To use this BOSH release, first upload it to your bosh:
-
-```
-bosh upload release https://bosh.io/d/github.com/cloudfoundry-community/docker-registry-boshrelease
-```
-
-To deploy it you will need the source repository that contains templates:
-
-```
-git clone https://github.com/cloudfoundry-community/docker-registry-boshrelease.git
-cd docker-registry-boshrelease
+```plain
+credhub get -n /bucc/docker-registry/docker_registry_certificate -j \
+    | jq -r ".value.ca" > ca.pem
+credhub get -n /bucc/docker-registry/docker_registry_password -j \
+    | jq -r ".value" > password
 ```
 
-To use BOSH v2 manifests, have a look at `templates/docker-registry.yml`, otherwise
-create the manifests using the traditional way with `templates/make_manifest`
+We can now interact with the Registry via its API:
 
-For AWS EC2, create a single VM:
-
-```
-templates/make_manifest aws-ec2
-bosh -n deploy
+```plain
+$ curl https://10.244.0.34/v2/_catalog -u "admin:$(cat password)" --cacert ca.pem
+{"repositories":[]}
 ```
 
-For developers of the release using [bosh-lite](https://github.com/cloudfoundry/bosh-lite), you can quickly create a deployment manifest and deploy:
+Now add ca.pem to system CA (please let use know if there's a way for `docker login` to consume a local self-signed CA). For example, in Keychain it may look like:
 
-```
-templates/make_manifest warden
-bosh -n deploy
-```
+![keychain](https://p198.p4.n0.cdn.getcloudapp.com/items/p9u5lR81/docker-registry-ca-keychain.png?v=0a5b64b4ab0ebf3538ad61d35d45557f)
 
-#### Override security groups
+We can now `docker login` to our registry, tag `ubuntu:latest` as `10.244.0.34/ubuntu` and push it to our registry:
 
-For AWS & Openstack, the default deployment assumes there is a `default` security group. If you wish to use a different security group(s) then you can pass in additional configuration when running `make_manifest` above.
-
-Create a file `my-networking.yml`:
-
-```yaml
----
-networks:
-  - name: docker-registry1
-    type: dynamic
-    cloud_properties:
-      security_groups:
-        - docker_registry
+```bash
+docker login -u admin -p "$(cat password)" 10.244.0.34
+docker tag ubuntu 10.244.0.34/ubuntu
+docker push 10.244.0.34/ubuntu
 ```
 
-Where `- docker_registry` means you wish to use an existing security group called `docker_registry`.
+Our registry API confirms it now has the `ubuntu` image:
 
-You now suffix this file path to the `make_manifest` command:
-
+```plain
+$ curl https://10.244.0.34/v2/_catalog -u "admin:$(cat password)"
+{"repositories":["ubuntu"]}
 ```
-templates/make_manifest openstack-nova my-networking.yml
-bosh -n deploy
-```
-
-Access restrictions
------------------------
-
-The registry can be available for administrative and reading purposes on different rules:
-- for **administrative and reading** purposes:
-  - default port: 443 (`docker.proxy.port`)
-  - default authentication: basic
-- you can enable **readonly access** without authentication by setting `docker.proxy.only_auth_for_admin=false`:
-  - default port: 444 (`docker.proxy.readonly_port`)
-  - default authentication: none
-
-#### Basic authentication
-
-You have to create the new password just like for `.htpasswd` file:
-```
-htpasswd -nb docker my-very-unique-password
-```
-
-Update the `manifests/docker-registry.yml` with the new password hash:
-
-```
-instance_groups:
-  - name: docker-registry
-    properties:
-      docker:
-        proxy:
-          auth_basic:
-            docker: "$apr1$EyknLHps$aOq105nTuANVeSOfl/Pla1"
-```
-
-
-SSL settings for Docker
------------------------
-
-### Signed Certificate from a CA
-
-If you have a public domain (even if it's for internal use) you can get a free certificate from "Let’s Encrypt":
-- automated way: https://letsencrypt.org/
-- manual way: https://www.sslforfree.com/
-
-Update the `manifests/docker-registry.yml` with the SSL certificate:
-
-```
-instance_groups:
-  - name: docker-registry
-    properties:
-      docker:
-        proxy:
-          ssl:
-            cert: |+
-              -----BEGIN CERTIFICATE-----
-              ... certificate.crt ...
-              -----END CERTIFICATE-----
-              -----BEGIN CERTIFICATE-----
-              ... ca_bundle.crt ...
-              -----END CERTIFICATE-----
-            key: |+
-              -----BEGIN PRIVATE KEY-----
-              ... private.key ...
-              -----END PRIVATE KEY-----
-```
-
-
-### Self-signed Certificate 
-
-Getting docker working with a private registry can be a time-consuming
-task when you use a self-signed certificate. Those are the steps to make it easy (but also insecure):
-
-```
-# Define the IP of the Docker registry server. You could use a DNS name
-# but then you have to modify the settings of the file below
-REGISTRY_IP="assign the ip of the registry"
-
-# Create a folder for the process
-mkdir ssl
-
-# Create the configuration file for openssl settings
-cat <<EOF > ssl/insecure.cnf
-[req]
-distinguished_name = req_distinguished_name
-x509_extensions = v3_req
-prompt = no
-
-[req_distinguished_name]
-C = NL
-ST = Holland
-L = Dordrecht
-O = Springer Nature
-CN = *
-
-[v3_req]
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer
-basicConstraints = CA:TRUE
-subjectAltName = @alt_names
-
-[alt_names]
-IP = $REGISTRY_IP
-DNS.1 = *
-DNS.2 = *.*
-DNS.3 = *.*.*
-DNS.4 = *.*.*.*
-DNS.5 = *.*.*.*.*
-DNS.6 = *.*.*.*.*.*
-DNS.7 = *.*.*.*.*.*.*
-
-EOF
-
-# Run openssl with the previous settings to create the self-signed certificate
-openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout ssl/registry.key -out ssl/registry.cert -config ssl/insecure.cnf -days 3650
-```
-
-Assign the content of the file `ssl/registry.key` to
-`docker.proxy.ssl.key` property and the content of `ssl/registry.cert` to `docker.proxy.ssl.cert`. Re-deploy if it is needed.
-
-Now it is time to configure the local docker daemon to accept the
-new Registry certificates. Docker daemon uses the system certificates,
-so we have to include the CA certificate there (On Ubuntu):
-
-```
-# Copy CA cert to system certificates folder
-sudo cp ssl/registry.cert /usr/share/ca-certificates/
-# Enable the new CA
-sudo update-ca-certificates
-# Restart Docker
-sudo service docker restart
-```
-
-Now you can push an image to the private Docker Registry:
-
-```
-# docker push 10.230.30.76:443/bosh
-The push refers to a repository [10.230.30.76:443/bosh]
-5f70bf18a086: Pushed
-587d5d1f5fec: Pushed
-dc5fe436f9a6: Pushed
-82cfb997c4aa: Pushed
-a96da73480aa: Pushed
-8d978c6d6037: Pushed
-3fb897e02c04: Pushed
-bb1d2c69066a: Pushed
-5ee9df15e635: Pushed
-14d1e894d916: Pushed
-fe17e7c4c5c1: Pushed
-3eb2e43b8463: Pushed
-69e57e993b01: Pushed
-e678c68d0466: Pushed
-6333a97cf74a: Pushed
-44599e8fdbd0: Pushed
-c8bff16118ee: Pushed
-62f86f3d6a38: Pushed
-b4f99d457706: Pushed
-f1869edf32d7: Pushed
-10ee77e0916d: Pushed
-0050a91818d4: Pushed
-cba62530f74a: Pushed
-d7a905e2ee84: Pushed
-a739ea00a948: Pushed
-470641744213: Pushed
-latest: digest: sha256:74ca3932f4cda9b1bf31b38518e35b8cc52cda3fa6ec767dacacafc2fb27f690 size: 7208
-```
-
-Links with more information
- * https://github.com/docker/docker/issues/8849
- * https://github.com/docker/distribution/issues/1731

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ $ curl https://docker-registry.bosh/v2/_catalog -u "admin:$(cat /tmp/password)" 
 
 ## Expose Docker Registry via Static IP
 
+Delete the TLS certificate for the Docker Registry, so that a new one will be generated that includes both the new static IP, and the `docker-registry.bosh` hostname:
+
+```plain
+credhub delete -n /bucc/docker-registry/docker_registry_certificate
+```
+
+Select an available static IP from the Cloud Config. We'll use 10.244.0.34 below, and re-deploy the Docker Registry with the `manifests/operators/static-ip.yml` operator file:
+
+```plain
+bosh -d docker-registry deploy manifests/docker-registry.yml \
+    -o manifests/operators/static-ip.yml \
+    -v ip=10.244.0.34
+```
+
+
 Now add ca.pem to system CA (please let use know if there's a way for `docker login` to consume a local self-signed CA). For example, in Keychain it may look like:
 
 ![keychain](https://p198.p4.n0.cdn.getcloudapp.com/items/p9u5lR81/docker-registry-ca-keychain.png?v=0a5b64b4ab0ebf3538ad61d35d45557f)

--- a/manifests/docker-registry.yml
+++ b/manifests/docker-registry.yml
@@ -15,6 +15,7 @@ instance_groups:
     azs: [z1]
     networks:
       - name: default
+        static_ips: [((ip))]
     jobs:
       - name: registry
         release: docker-registry
@@ -30,63 +31,11 @@ instance_groups:
             maxmemory: "2g"
         proxy:
           auth_basic:
-            docker: "{PLAIN}sekrit"
+            admin: "{PLAIN}((docker_registry_password))"
           only_auth_for_admin: false
           ssl:
-            # don't worry, this is a silly self-signed certificate, for testing
-            cert: |+
-              -----BEGIN CERTIFICATE-----
-              MIIDxTCCAq2gAwIBAgIJAKHr+jYSc6p5MA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
-              BAYTAlVTMREwDwYDVQQIDAhOZXcgWW9yazEQMA4GA1UEBwwHQnVmZmFsbzEhMB8G
-              A1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMSIwIAYDVQQDDBlkb2NrZXIu
-              MTAuMjQ0LjQuMTEueGlwLmlvMB4XDTE2MDMwNzE5MTQxNVoXDTE3MDMwNzE5MTQx
-              NVoweTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE5ldyBZb3JrMRAwDgYDVQQHDAdC
-              dWZmYWxvMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxIjAgBgNV
-              BAMMGWRvY2tlci4xMC4yNDQuNC4xMS54aXAuaW8wggEiMA0GCSqGSIb3DQEBAQUA
-              A4IBDwAwggEKAoIBAQDFE0WaKQhHYxuNZdW6quZL/DZ3Q2TafgMBB9w3chxbGlmr
-              W9k52gaM/Ix04DV4xcKafduxaS/+zAJSpw5x7EXBn+7Pg5DGD5E3uyGP5tQbOdJE
-              tkHW+oETh5oDvgrh1ykUtsQNtvFeokwmzDBZ0qWBG4R/pSPmb1yQKr3H4yEKUmfl
-              wUU+chbeAy2s5TNWUuj5hBsfYoAqH3FWp6+NcWMDO3l9fpjZEOB3cmXClFWYm1LD
-              SUenhnm8IE2JhjO/Ikr3v+dIPS8De23nluOk4y670ncpuEZOjnLd7jhwoPFgFY0l
-              GGHHhMLIx4QKyt8lueRuzAkLeGfje91Sn5G4BVFXAgMBAAGjUDBOMB0GA1UdDgQW
-              BBQMCr9VGYmcw14C32yawH71Le2f1TAfBgNVHSMEGDAWgBQMCr9VGYmcw14C32ya
-              wH71Le2f1TAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAP3vcHFNEa
-              NT/sQORPDAtzKx0pJp2z+B5dln8c+m7jjZEPDyBJOlVgMOIPJqLgATEzh2UfSgfM
-              mZLnRM4e4lQHjRiZkClmq2zinQb4yjkAlAGWrr+jBE0ngLpPqq258rUZfON64j+7
-              Th3YeatwDoTkvuXYzMUUi8upkK/0K2+tAxZqitUkke85729owi4QW8sRr9DqHqqp
-              4zJ6HZe+Q45pPg+DUyWIBJ2Jty88BEOoLmwb+/dsh/Xtf6Fdh5z64qgmUtTFkiPS
-              bsbPRzB0AaTA65alWviLBOmJn9S4xOv4XUC5scqsXnjPFzFT/XxA6iDux/xBMieT
-              7y9cXpKlGsDT
-              -----END CERTIFICATE-----
-            key: |+
-              -----BEGIN PRIVATE KEY-----
-              MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDFE0WaKQhHYxuN
-              ZdW6quZL/DZ3Q2TafgMBB9w3chxbGlmrW9k52gaM/Ix04DV4xcKafduxaS/+zAJS
-              pw5x7EXBn+7Pg5DGD5E3uyGP5tQbOdJEtkHW+oETh5oDvgrh1ykUtsQNtvFeokwm
-              zDBZ0qWBG4R/pSPmb1yQKr3H4yEKUmflwUU+chbeAy2s5TNWUuj5hBsfYoAqH3FW
-              p6+NcWMDO3l9fpjZEOB3cmXClFWYm1LDSUenhnm8IE2JhjO/Ikr3v+dIPS8De23n
-              luOk4y670ncpuEZOjnLd7jhwoPFgFY0lGGHHhMLIx4QKyt8lueRuzAkLeGfje91S
-              n5G4BVFXAgMBAAECggEBAIl74FqjtXrX0SjbmjcXcoIf+X9KLNmgf0gAy8iCevWz
-              dErvUKPjTh6dMP94StVuYUyV8OXbk/gVKqmukY04X5GsmVV7W0xRH+XZTpitV9uG
-              gwIcg+IN8G5Hc1KZCc5z49zng+5tagWzA50tZa3EHmHraIwEEP95QQHyT2NbOHmR
-              uJ4+dhnH0HdPNgqo4b0kaEj15sjLjMmfahBgHHLSOOMrgmKC9/a8su9P6ikXniR6
-              GwVUcA/oeiuwhzuQGktPHz85GlLi663IzIZzJt8yocoUNLG6XQdMLQG/zOlidFl6
-              5mG3ifgN+xPFc9vwRj/gU4ySG7s1RY7P9WXpDulfAIECgYEA+GKPYbz/4Kmi8RN9
-              JmV2rTMr2kW/6ehkpDKIqWZESmpPzS3sKswXl02QPRBTmklkb9HaA2mSYhMQ9ljP
-              UlwXBsqaAZjzkkrVoKBeRcNa6X8jsDVUXtpdQiBjt4rTE+yir8VEFwCEr2cg3tl7
-              fgIzb2Ji6Mh49NQRF/T2FV40OykCgYEAyx4CbVYvuWmMdq/mNjUjKE3QK1sq3XNt
-              jh3WeZJgaOIt+4S2hTMoRAjaoBFXZuTTiQs9Pu6TJUyiS25mZZnR01k5SNZRo2+9
-              +lh4BAs6O6thg4F/daqzP82M7g4T76kG6TgQQEw4GJFaoZntOQCMfDujFpnks/HG
-              7yvFDVYzOH8CgYEA86PSG0BGCfy7/Rdt0mUCdUBViqSSbIHtfnanQOs0n34Kyyt5
-              lj1eAqctjgheyV+mal0BKgm7cgJbyBkzPAli+OFxEZITkfNf+1BzSKEooxN4UVbu
-              bKBri/qzdY1yIQAkUKACe0Gh5WAWiSHxlZfZFi/+73H928HNBp/dZvZh64kCgYEA
-              wDLPXSKW2j3UGmLr1hOGBxdKihwkfZRB8J6vWi52aAjONhgolfYIfghax+hg6g5R
-              VHZ8J9adCkhvsizvW+insfPVzuRuL9cGz6NzPXBaVCghh8y8DV3Pa+pXFtPfbYJl
-              9b2FMzJsSmMQfaYn4S5xwQS1mCdbUCLSeXLTbYFJyoUCgYBJbRlN5/640YYgywU6
-              PDIZFZmdQp33duh/L4ym08PjaAlyfDX96vHOP8pKxRIyaqb2TVDbpm7T4oJbr79G
-              B9f/jV291iU/978Rz22zIN9Y48s2hmu/Skou0+/jFTuBZDeJrWEAd9wxFr9ZGYW2
-              JObPWXF5f5F8UTGjZJT6fnduEg==
-              -----END PRIVATE KEY-----
+            cert: ((docker_registry_certificate.certificate))
+            key: ((docker_registry_certificate.private_key))
 
 update:
   canaries: 1
@@ -94,6 +43,25 @@ update:
   serial: false
   canary_watch_time: 1000-60000
   update_watch_time: 1000-60000
+
+variables:
+  - name: docker_registry_password
+    type: password
+  - name: docker_registry_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: docker_registry_ca
+  - name: docker_registry_certificate
+    type: certificate
+    options:
+      ca: docker_registry_ca
+      common_name: docker_registry
+      extended_key_usage:
+        - client_auth
+        - server_auth
+      alternative_names:
+      - ((ip))
 
 releases:
 - name:    docker-registry

--- a/manifests/docker-registry.yml
+++ b/manifests/docker-registry.yml
@@ -15,12 +15,20 @@ instance_groups:
     azs: [z1]
     networks:
       - name: default
-        static_ips: [((ip))]
     jobs:
       - name: registry
         release: docker-registry
       - name: proxy
         release: docker-registry
+        custom_provider_definitions:
+        - name: registry
+          type: https
+          shared: true
+        provides:
+          registry:
+            aliases:
+            - domain: docker-registry.bosh
+              health_filter: "healthy"
       - name: cache
         release: docker-registry
     properties:
@@ -61,7 +69,7 @@ variables:
         - client_auth
         - server_auth
       alternative_names:
-      - ((ip))
+      - docker-registry.bosh
 
 releases:
 - name:    docker-registry

--- a/manifests/operators/create.yml
+++ b/manifests/operators/create.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /releases/name=docker-registry
+  value:
+    name: docker-registry
+    url: .
+    version: create

--- a/manifests/operators/static-ip.yml
+++ b/manifests/operators/static-ip.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=docker-registry/networks/name=default/static_ips?
+  value: [((ip))]
+
+- type: replace
+  path: /variables/name=docker_registry_certificate/options/alternative_names/-
+  value: ((ip))


### PR DESCRIPTION
This PR generates TLS certificates for the Docker Registry.

It assumes BOSH DNS is enabled, and the default manifest exposes `docker-registry.bosh` hostname.

An operator is provided to also support a static IP.