### PR TITLE
Update config to be compatible with Bionic stemcell

### DIFF
--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -28,7 +28,7 @@ fi
 # Build Autoconf package
 echo "Building Autoconf ${AUTOCONF_VERSION}..."
 cd ${BOSH_COMPILE_TARGET}/autoconf-${AUTOCONF_VERSION}
-./configure
+./configure --with-cc-opt="-Wno-error"
 make -j${CPUS}
 make install
 
@@ -36,7 +36,7 @@ make install
 echo "Building bridge-utils ${BRIDGE_UTILS_VERSION}..."
 cd ${BOSH_COMPILE_TARGET}/bridge-utils-${BRIDGE_UTILS_VERSION}
 autoconf
-./configure --prefix=${BOSH_INSTALL_TARGET}
+./configure --prefix=${BOSH_INSTALL_TARGET} --with-cc-opt="-Wno-error"
 make -j${CPUS}
 make install
 

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -38,6 +38,7 @@ export ZLIB_LIB=/var/vcap/packages/nginx/lib
 
 pushd nginx-1.10.1
     ./configure \
+    --with-cc-opt="-Wno-error" \
     --user=vcap --group=vcap \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-Wl,-rpath,$OPENSSL_LIB,-rpath,$ZLIB_LIB" \


### PR DESCRIPTION
Changing configure switch so the new gcc compiler will not error out (treating warning as error) for bionic stemcells. This has been tested and working fine.